### PR TITLE
Fix parsing of key-values where the value is empty

### DIFF
--- a/src/INI-Parser-Tests/IniReaderTest.class.st
+++ b/src/INI-Parser-Tests/IniReaderTest.class.st
@@ -5,6 +5,21 @@ Class {
 }
 
 { #category : #tests }
+IniReaderTest >> testEmptyValueDontEatNextKeyValuePair [
+
+	| reader parsed expected |
+	expected := Dictionary new.
+	expected at: '' put: Dictionary new.
+	expected at: '' at: 'server' put: ''.
+	expected at: '' at: 'port' put: '143'.
+
+	reader := IniReader on: 'server=<l>port=143' expandMacros readStream.
+	parsed := reader parse.
+
+	self assert: parsed equals: expected
+]
+
+{ #category : #tests }
 IniReaderTest >> testParse [
 	| r v expected |	
 		

--- a/src/INI-Parser/IniReader.class.st
+++ b/src/INI-Parser/IniReader.class.st
@@ -218,8 +218,10 @@ IniReader >> parseKeyValuePair [
 	key := String streamContents: [ :stream | 
 		[ readStream atEnd or: [ readStream peek = self keyValueSeparator  ] ] 
 			whileFalse: [ stream nextPut: self parseCharacter ] ].
-	self expectChar: self keyValueSeparator .
-	
+		
+	(readStream peekFor: self keyValueSeparator) 
+		ifFalse: [self error: ('<1s> expected' expandMacrosWith: self keyValueSeparator asString)].
+		
 	value := String streamContents: [ :stream | 
 		[ readStream atEnd or: [ (readStream peek = Character cr) | (readStream peek = Character lf) ] ] 
 			whileFalse: [ stream nextPut: self parseCharacter ] ].


### PR DESCRIPTION
In case some of the key-value pairs in the INI file have an empty value
(something like `key=`), the parser was skipping whitespace including
line feeds and putting the whole next line as the value of the key 
in the previous line.

A file like the following one:

```ini
key=
key2=value2
```

was producing a dictionary with only one key `key` whose value was `key2=value2`